### PR TITLE
Upgrade action-gh-release from v2 to v3

### DIFF
--- a/.github/workflows/build-mesa-host.yml
+++ b/.github/workflows/build-mesa-host.yml
@@ -106,7 +106,7 @@ jobs:
       - id: create_release
         name: release
         if: ${{ steps.check_release.outputs.release_exists == 'false' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: true


### PR DESCRIPTION
Ref: https://github.com/softprops/action-gh-release/releases/tag/v3.0.0 

Fixes:

Checkout LibreELEC/LibreELEC.tv and check latest commit Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/